### PR TITLE
Infer image registry

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -73,7 +73,7 @@ func buildCmdFn(cmd *cobra.Command, args []string) image.FunctionImage {
 		serviceName = imageName
 	}
 
-	ctx, err := parseSystemContext(cmd)
+	ctx, err := config.ParseSystemContext(cmd)
 	if err != nil {
 		panic(fmt.Sprintf("Error while trying to infer context: %v", err))
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"github.com/containers/buildah/pkg/parse"
-	"github.com/containers/image/types"
-	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"strings"
@@ -25,26 +22,6 @@ func boolFlagWithBind(envName string, defaultValue bool, usage string) {
 	flagName := strings.ReplaceAll(envName, "_", "-")
 	rootCmd.PersistentFlags().Bool(flagName, defaultValue, usage)
 	viper.BindPFlag(envName, rootCmd.PersistentFlags().Lookup(flagName))
-}
-
-func parseSystemContext(cmd *cobra.Command) (*types.SystemContext, error) {
-	ctx, err := parse.SystemContextFromOptions(cmd)
-	if err != nil {
-		return nil, err
-	}
-
-	if config.ImageRegistryUsername != "" {
-		ctx.DockerAuthConfig = &types.DockerAuthConfig{
-			Username: config.ImageRegistryUsername,
-			Password: config.ImageRegistryPassword,
-		}
-	}
-
-	ctx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!config.ImageRegistryTLSVerify)
-	ctx.OCIInsecureSkipTLSVerify = !config.ImageRegistryTLSVerify
-	ctx.DockerDaemonInsecureSkipTLSVerify = !config.ImageRegistryTLSVerify
-
-	return ctx, nil
 }
 
 func buildFlags(cmd *cobra.Command) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var rootCmd = &cobra.Command{
 	Long:  `TODO`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		unshare.MaybeReexecUsingUserNamespace(false) // Do crazy stuff that allows buildah to work
-		config.InitVariables()
+		config.InitVariables(cmd)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kfn.yaml or $(pwd)/.kfn.yaml")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kfn.yaml or $(pwd)/.kfn.yaml)")
 
 	rootCmd.PersistentFlags().BoolP(config.VERBOSE, "v", false, "verbose output")
 	viper.BindPFlag(config.VERBOSE, rootCmd.PersistentFlags().Lookup(config.VERBOSE))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,10 +21,6 @@ import (
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/spf13/cobra"
 	serving "knative.dev/serving/pkg/client/clientset/versioned"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 )
 
 // runCmd represents the run command

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,10 +20,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	serving "knative.dev/serving/pkg/client/clientset/versioned"
 	"os"
+	"path"
+	"path/filepath"
+	"strings"
 )
 
 // runCmd represents the run command
@@ -43,17 +44,9 @@ func init() {
 func runCmdFn(cmd *cobra.Command, args []string) {
 	functionImage := buildCmdFn(cmd, args)
 
-	var err error
-	var kconfig *rest.Config
-	if os.Getenv("KFN_IN_CLUSTER") == "true" {
-		kconfig, err = rest.InClusterConfig()
-	} else {
-		if config.Kubeconfig != "" {
-			kconfig, err = clientcmd.BuildConfigFromFlags("", config.Kubeconfig)
-		} else {
-			kconfig, err = clientcmd.BuildConfigFromKubeconfigGetter("", clientcmd.NewDefaultClientConfigLoadingRules().Load)
-		}
-	}
+	log.Infof("Image %s pushed", functionImage.ImageName)
+
+	kconfig, err := config.CreateK8sClientConfig()
 	if err != nil {
 		panic(fmt.Sprintf("Cannot create a k8s client config: %+v", err))
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,8 @@ require (
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/go-digest v1.0.0-rc1
-	github.com/pborman/uuid v1.2.0 // indirect
+	github.com/openshift/api v3.9.0+incompatible // indirect
+	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,15 @@ func InitVariables() {
 	} else {
 		log.SetLevel(log.WarnLevel)
 	}
+
+	var err error
+	ImageRegistry, ImageRegistryUsername, ImageRegistryPassword, err = inferImageRegistry()
+	if err != nil {
+		panic(err)
+	}
+
+	log.Infof("Using Kubeconfig: %s", Kubeconfig)
+	log.Infof("Using image registry: %s", ImageRegistry)
 }
 
 func GetBuildahIsolation() buildah.Isolation {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,10 @@ package config
 import (
 	"fmt"
 	"github.com/containers/buildah"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/image/types"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
 	"path"
@@ -37,7 +40,7 @@ var (
 	Kubeconfig             string
 )
 
-func InitVariables() {
+func InitVariables(cmd *cobra.Command) {
 	wd, _ := os.Getwd()
 
 	// Configure variables
@@ -60,13 +63,13 @@ func InitVariables() {
 	}
 
 	var err error
-	ImageRegistry, ImageRegistryUsername, ImageRegistryPassword, err = inferImageRegistry()
+	systemContext, err := ParseSystemContext(cmd)
+	ImageRegistry, ImageRegistryUsername, ImageRegistryPassword, err = inferImageRegistry(systemContext)
 	if err != nil {
 		panic(err)
 	}
 
 	log.Infof("Using Kubeconfig: %s", Kubeconfig)
-	log.Infof("Using image registry: %s", ImageRegistry)
 }
 
 func GetBuildahIsolation() buildah.Isolation {
@@ -105,4 +108,24 @@ func getEnvBoolOrDefault(envName string, defaultValue bool) bool {
 	} else {
 		return defaultValue
 	}
+}
+
+func ParseSystemContext(cmd *cobra.Command) (*types.SystemContext, error) {
+	ctx, err := parse.SystemContextFromOptions(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if ImageRegistryUsername != "" {
+		ctx.DockerAuthConfig = &types.DockerAuthConfig{
+			Username: ImageRegistryUsername,
+			Password: ImageRegistryPassword,
+		}
+	}
+
+	ctx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!ImageRegistryTLSVerify)
+	ctx.OCIInsecureSkipTLSVerify = !ImageRegistryTLSVerify
+	ctx.DockerDaemonInsecureSkipTLSVerify = !ImageRegistryTLSVerify
+
+	return ctx, nil
 }

--- a/pkg/config/k8s_client.go
+++ b/pkg/config/k8s_client.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+)
+
+func CreateK8sClientConfig() (*rest.Config, error) {
+	if os.Getenv("KFN_IN_CLUSTER") == "true" {
+		return rest.InClusterConfig()
+	} else {
+		if Kubeconfig != "" {
+			return clientcmd.BuildConfigFromFlags("", Kubeconfig)
+		} else {
+			return clientcmd.BuildConfigFromKubeconfigGetter("", clientcmd.NewDefaultClientConfigLoadingRules().Load)
+		}
+	}
+}

--- a/pkg/config/registry_inference.go
+++ b/pkg/config/registry_inference.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"fmt"
+	routev1typedclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+// To infer the image registry we:
+// 1. Try to read image registry from config/env/flag and check if there are credentials
+// 2. Try to infer ocp image registry. If there is one available, try to infer credentials from oc whoami
+func inferImageRegistry() (string, string, string, error) {
+	return imTryingToDoSomeFPInGoButItLooksAwful(inferImageRegistryFromEnv, inferImageRegistryFromOCPImageRegistry)
+}
+
+func inferImageRegistryFromEnv() (string, string, string, error) {
+	if viper.IsSet(REGISTRY) && viper.GetString(REGISTRY) != "" {
+		return viper.GetString(REGISTRY), viper.GetString(REGISTRY_USERNAME), viper.GetString(REGISTRY_PASSWORD), nil
+	} else {
+		return "", "", "", fmt.Errorf("Cannot find flag/env/config entry %s", REGISTRY)
+	}
+}
+
+func inferImageRegistryFromOCPImageRegistry() (string, string, string, error) {
+	config, err := CreateK8sClientConfig()
+	if err != nil {
+		return "", "", "", err
+	}
+	routeClient, err := routev1typedclient.NewForConfig(config)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	route, err := routeClient.Routes("openshift-image-registry").Get("default-route", v1.GetOptions{})
+	if err != nil {
+		return "", "", "", err
+	}
+
+	registryHost := route.Spec.Host
+
+	userClient, err := userv1typedclient.NewForConfig(config)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	me, err := userClient.Users().Get("~", v1.GetOptions{})
+	if err != nil {
+		return "", "", "", err
+	}
+	registryUsername := strings.Trim(me.Name, " ")
+	if registryUsername == "kube:admin" {
+		registryUsername = "kubeadmin" // Small workaround for this inconsistency
+	}
+
+	var registryPassword string
+	if config.BearerToken != "" {
+		registryPassword = strings.Trim(config.BearerToken, " ")
+	} else {
+		return "", "", "", fmt.Errorf("Trying to use image registry %s but i cannot find the credentials", registryHost)
+	}
+	log.Infof("Found image registry '%s' with username %s and pass %s", registryHost, registryUsername, registryPassword)
+	return registryHost, registryUsername, registryPassword, nil
+}
+
+func imTryingToDoSomeFPInGoButItLooksAwful(fs ...func() (string, string, string, error)) (string, string, string, error) {
+	errors := make([]error, 0)
+	for _, f := range fs {
+		if name, user, pass, err := f(); err != nil {
+			errors = append(errors, err)
+		} else {
+			return name, user, pass, nil
+		}
+	}
+	return "", "", "", fmt.Errorf("Cannot infer the image registry: %+v", errors)
+}

--- a/pkg/config/registry_inference.go
+++ b/pkg/config/registry_inference.go
@@ -1,31 +1,43 @@
 package config
 
 import (
+	"context"
 	"fmt"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/image/docker"
+	"github.com/containers/image/types"
 	routev1typedclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+	containers_config "github.com/containers/image/pkg/docker/config"
 )
 
 // To infer the image registry we:
 // 1. Try to read image registry from config/env/flag and check if there are credentials
 // 2. Try to infer ocp image registry. If there is one available, try to infer credentials from oc whoami
-func inferImageRegistry() (string, string, string, error) {
-	return tryDifferentRegistryConfigs(inferImageRegistryFromEnv, inferImageRegistryFromOCPImageRegistry)
+func inferImageRegistry(systemContext *types.SystemContext) (string, string, string, error) {
+	return tryDifferentRegistryConfigs(systemContext, inferImageRegistryFromEnv, inferImageRegistryFromOCPImageRegistry)
 }
 
-func inferImageRegistryFromEnv() (string, string, string, error) {
+func inferImageRegistryFromEnv(systemContext *types.SystemContext) (string, string, string, error) {
 	if viper.IsSet(REGISTRY) && viper.GetString(REGISTRY) != "" {
-		return viper.GetString(REGISTRY), viper.GetString(REGISTRY_USERNAME), viper.GetString(REGISTRY_PASSWORD), nil
+		registry := viper.GetString(REGISTRY)
+		username := viper.GetString(REGISTRY_USERNAME)
+		password := viper.GetString(REGISTRY_PASSWORD)
+		if err := validCredentials(*systemContext, registry, username, password); err == nil {
+			return registry, username, password, nil
+		} else {
+			return "", "", "", err
+		}
 	} else {
 		return "", "", "", fmt.Errorf("Cannot find flag/env/config entry %s", REGISTRY)
 	}
 }
 
-func inferImageRegistryFromOCPImageRegistry() (string, string, string, error) {
+func inferImageRegistryFromOCPImageRegistry(systemContext *types.SystemContext) (string, string, string, error) {
+	// Try to infer the address
 	config, err := CreateK8sClientConfig()
 	if err != nil {
 		return "", "", "", err
@@ -40,8 +52,20 @@ func inferImageRegistryFromOCPImageRegistry() (string, string, string, error) {
 		return "", "", "", err
 	}
 
-	registryHost := route.Spec.Host
+	registry := route.Spec.Host
 
+	// Check if user provided credentials
+	if viper.IsSet(REGISTRY_USERNAME) {
+		username := viper.GetString(REGISTRY_USERNAME)
+		password := viper.GetString(REGISTRY_PASSWORD)
+		if err := validCredentials(*systemContext, registry, username, password); err == nil {
+			return registry, username, password, nil
+		} else {
+			return "", "", "", err
+		}
+	}
+
+	// Nope, try to infer credentials
 	userClient, err := userv1typedclient.NewForConfig(config)
 	if err != nil {
 		return "", "", "", err
@@ -60,20 +84,38 @@ func inferImageRegistryFromOCPImageRegistry() (string, string, string, error) {
 	if config.BearerToken != "" {
 		registryPassword = strings.Trim(config.BearerToken, " ")
 	} else {
-		return "", "", "", fmt.Errorf("Trying to use image registry %s but i cannot find the credentials", registryHost)
+		return "", "", "", fmt.Errorf("Trying to use image registry %s but i cannot find the credentials", registry)
 	}
-	log.Infof("Found image registry '%s' with username %s and pass %s", registryHost, registryUsername, registryPassword)
-	return registryHost, registryUsername, registryPassword, nil
+
+	if err := validCredentials(*systemContext, registry, registryUsername, registryPassword); err == nil {
+		return registry, registryUsername, registryPassword, nil
+	} else {
+		return "", "", "", err
+	}
 }
 
-func tryDifferentRegistryConfigs(fs ...func() (string, string, string, error)) (string, string, string, error) {
+func tryDifferentRegistryConfigs(systemContext *types.SystemContext, fs ...func(*types.SystemContext) (string, string, string, error)) (string, string, string, error) {
 	errors := make([]error, 0)
 	for _, f := range fs {
-		if name, user, pass, err := f(); err != nil {
+		if name, user, pass, err := f(systemContext); err != nil {
 			errors = append(errors, err)
 		} else {
 			return name, user, pass, nil
 		}
 	}
 	return "", "", "", fmt.Errorf("Cannot infer the image registry: %+v", errors)
+}
+
+func validCredentials(systemContext types.SystemContext, registry string, username string, password string) error {
+	server := parse.RegistryFromFullName(parse.ScrubServer(registry))
+	if username == "" {
+		username, password, _ = containers_config.GetAuthentication(&systemContext, server)
+	}
+	if username != "" {
+		systemContext.DockerAuthConfig = &types.DockerAuthConfig{
+			Username: username,
+			Password: password,
+		}
+	}
+	return docker.CheckAuth(context.TODO(), &systemContext, username, password, server)
 }

--- a/pkg/config/registry_inference.go
+++ b/pkg/config/registry_inference.go
@@ -14,7 +14,7 @@ import (
 // 1. Try to read image registry from config/env/flag and check if there are credentials
 // 2. Try to infer ocp image registry. If there is one available, try to infer credentials from oc whoami
 func inferImageRegistry() (string, string, string, error) {
-	return imTryingToDoSomeFPInGoButItLooksAwful(inferImageRegistryFromEnv, inferImageRegistryFromOCPImageRegistry)
+	return tryDifferentRegistryConfigs(inferImageRegistryFromEnv, inferImageRegistryFromOCPImageRegistry)
 }
 
 func inferImageRegistryFromEnv() (string, string, string, error) {
@@ -66,7 +66,7 @@ func inferImageRegistryFromOCPImageRegistry() (string, string, string, error) {
 	return registryHost, registryUsername, registryPassword, nil
 }
 
-func imTryingToDoSomeFPInGoButItLooksAwful(fs ...func() (string, string, string, error)) (string, string, string, error) {
+func tryDifferentRegistryConfigs(fs ...func() (string, string, string, error)) (string, string, string, error) {
 	errors := make([]error, 0)
 	for _, f := range fs {
 		if name, user, pass, err := f(); err != nil {

--- a/pkg/kfn.go
+++ b/pkg/kfn.go
@@ -82,10 +82,6 @@ func Build(location string, language languages.Language, imageName string, image
 
 	log.Info("Starting build image")
 
-	//TODO remove
-	log.Infof("System context: %+v", systemContext)
-	log.Infof("Docker auth config: %+v", systemContext.DockerAuthConfig)
-
 	return languageManager.BuildImage(systemContext, imageName, imageTag)
 }
 

--- a/pkg/kfn.go
+++ b/pkg/kfn.go
@@ -82,6 +82,10 @@ func Build(location string, language languages.Language, imageName string, image
 
 	log.Info("Starting build image")
 
+	//TODO remove
+	log.Infof("System context: %+v", systemContext)
+	log.Infof("Docker auth config: %+v", systemContext.DockerAuthConfig)
+
 	return languageManager.BuildImage(systemContext, imageName, imageTag)
 }
 

--- a/pkg/languages/js/js.go
+++ b/pkg/languages/js/js.go
@@ -102,7 +102,7 @@ func (j jsLanguageManager) BuildImage(systemContext *types.SystemContext, imageN
 
 	builder.SetCmd([]string{"node", "/home/node/src/index.js"})
 
-	return util.CommitImage(builder, imageName, imageTag)
+	return util.CommitImage(builder, systemContext, imageName, imageTag)
 }
 
 func (j jsLanguageManager) DownloadRuntimeIfRequired() error {

--- a/pkg/util/image_builder.go
+++ b/pkg/util/image_builder.go
@@ -83,7 +83,7 @@ func RunCommands(builder *buildah.Builder, commands ...BuildCommand) error {
 	return nil
 }
 
-func CommitImage(builder *buildah.Builder, imageName string, imageTag string) (image.FunctionImage, error) {
+func CommitImage(builder *buildah.Builder, ctx *types.SystemContext, imageName string, imageTag string) (image.FunctionImage, error) {
 	img := image.FunctionImage{
 		ImageName: imageName,
 		Tag:       imageTag,
@@ -97,6 +97,7 @@ func CommitImage(builder *buildah.Builder, imageName string, imageTag string) (i
 
 	_, _, _, err = builder.Commit(context.TODO(), imageRef, buildah.CommitOptions{
 		PreferredManifestType: buildah.Dockerv2ImageManifest,
+		SystemContext:         ctx,
 	})
 
 	return img, err


### PR DESCRIPTION
Add an inference logic for the image registry:
> // 1. Try to read image registry from config/env/flag and check if there are credentials
// 2. Try to infer ocp image registry. If there is one available, try to infer credentials from oc whoami

Since the inference on the ocp image registry credentials is way unpredictable/magic/too much things must be in the exact place to make it working, does it makes sense to infer only the registry address? @lance what's your take on this?