### PR TITLE
Reorganized directory flags

### DIFF
--- a/.kfn.yaml
+++ b/.kfn.yaml
@@ -1,1 +1,0 @@
-docker_registry: "docker.io/slinkydeveloper"

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -19,17 +19,36 @@ import (
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/slinkydeveloper/kfn/pkg/util"
 	"github.com/spf13/cobra"
+	"path/filepath"
+)
+
+var (
+	global bool
 )
 
 // cleanCmd represents the clean command
 var cleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Clean runtime & target directory",
+	Use:   "clean <function_name>",
+	Short: "Clean runtime & target directory for the provided function",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return util.RmR(config.TargetDir, config.RuntimeDir, config.EditingDir)
+		if global {
+			return util.RmR(config.GetKfnDir())
+		}
+		functionPath := args[0]
+		functionPath, err := filepath.Abs(functionPath)
+		if err != nil {
+			return err
+		}
+
+		targetDir := config.GetTargetDir(functionPath)
+		editingDir := config.GetEditingDir(functionPath)
+
+		return util.RmR(targetDir, editingDir)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(cleanCmd)
+
+	cleanCmd.Flags().BoolVarP(&global, "global", "g", false, "Clean global kfn directory (default false)")
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -31,7 +31,7 @@ var editCmd = &cobra.Command{
 	Use:   "edit <function> <editor>",
 	Args:  cobra.ExactArgs(2),
 	Short: "Open the editor of your choice. Supported editors: idea, vscode",
-	RunE: editCmdFn,
+	RunE:  editCmdFn,
 }
 
 func init() {
@@ -45,6 +45,8 @@ func editCmdFn(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	editingDir := config.GetEditingDir(functionPath)
+
 	language := languages.GetLanguage(path.Ext(functionPath))
 	if language == languages.Unknown {
 		return fmt.Errorf("Unknown language for function %s", functionPath)
@@ -55,12 +57,12 @@ func editCmdFn(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Cannot recognize editor %s", args[1])
 	}
 
-	err = util.MkdirpIfNotExists(config.EditingDir)
+	err = util.MkdirpIfNotExists(editingDir)
 	if err != nil {
 		return err
 	}
 
-	directory , descriptorFilename , err := language.ConfigureEditingDirectory(functionPath)
+	directory, descriptorFilename, err := language.ConfigureEditingDirectory(functionPath, editingDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -16,7 +16,9 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"strings"
 )
@@ -27,20 +29,29 @@ var (
 	serviceName string
 )
 
-func stringFlagWithBind(envName, defaultValue, usage string) {
+func stringFlagWithBind(flagSet *pflag.FlagSet, envName, shorthandFlag, defaultValue, usage string) {
 	flagName := strings.ReplaceAll(envName, "_", "-")
-	rootCmd.PersistentFlags().String(flagName, defaultValue, usage)
-	viper.BindPFlag(envName, rootCmd.PersistentFlags().Lookup(flagName))
+	flagSet.StringP(flagName, shorthandFlag, defaultValue, usage)
+	_ = viper.BindPFlag(envName, flagSet.Lookup(flagName))
 }
 
-func boolFlagWithBind(envName string, shorthandFlag string, defaultValue bool, usage string) {
+func boolFlagWithBind(flagSet *pflag.FlagSet, envName string, shorthandFlag string, defaultValue bool, usage string) {
 	flagName := strings.ReplaceAll(envName, "_", "-")
-	rootCmd.PersistentFlags().BoolP(flagName, shorthandFlag, defaultValue, usage)
-	viper.BindPFlag(envName, rootCmd.PersistentFlags().Lookup(flagName))
+	flagSet.BoolP(flagName, shorthandFlag, defaultValue, usage)
+	_ = viper.BindPFlag(envName, flagSet.Lookup(flagName))
 }
 
 func buildFlags(cmd *cobra.Command) {
+	stringFlagWithBind(cmd.Flags(), config.REGISTRY, "", "", "Docker registry where to push the image")
+	stringFlagWithBind(cmd.Flags(), config.REGISTRY_USERNAME, "", "", "Username to access docker registry")
+	stringFlagWithBind(cmd.Flags(), config.REGISTRY_PASSWORD, "", "", "Password to access docker registry")
+	boolFlagWithBind(cmd.Flags(), config.REGISTRY_TLS_VERIFY, "", true, "TLS Verify when accessing the docker registry")
 	cmd.Flags().StringVarP(&imageName, "imageName", "i", "", "Image name")
 	cmd.Flags().StringVarP(&imageTag, "imageTag", "t", "", "Image tag")
 	cmd.Flags().StringVarP(&serviceName, "serviceName", "s", "", "KNative service name")
+}
+
+func runFlags(cmd *cobra.Command) {
+	stringFlagWithBind(cmd.Flags(), config.KUBECONFIG, "", "", "Kubeconfig")
+	stringFlagWithBind(cmd.Flags(), config.NAMESPACE, "", "default", "K8s namespace where to run the service")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 	Long:  `TODO`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		config.InitLogging()
-		config.InitDirVariables()
+		config.InitKfnDir()
 	},
 }
 
@@ -47,14 +47,8 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	stringFlagWithBind(config.CONFIG, "", "config file (default is $HOME/.kfn.yaml or $(pwd)/.kfn.yaml)")
-	boolFlagWithBind(config.VERBOSE, "v", false, "verbose output")
-	stringFlagWithBind(config.REGISTRY, "", "Docker registry where to push the image")
-	stringFlagWithBind(config.REGISTRY_USERNAME, "", "Username to access docker registry")
-	stringFlagWithBind(config.REGISTRY_PASSWORD, "", "Password to access docker registry")
-	boolFlagWithBind(config.REGISTRY_TLS_VERIFY, "", true, "TLS Verify when accessing the docker registry")
-	stringFlagWithBind(config.KUBECONFIG, "", "Kubeconfig")
-	stringFlagWithBind(config.NAMESPACE, "default", "K8s namespace where to run the service")
+	stringFlagWithBind(rootCmd.PersistentFlags(), config.CONFIG, "", "", "config file (default is $HOME/.kfn.yaml or $(pwd)/.kfn.yaml)")
+	boolFlagWithBind(rootCmd.PersistentFlags(), config.VERBOSE, "v", false, "verbose output")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,6 +41,7 @@ var runCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(runCmd)
 	buildFlags(runCmd)
+	runFlags(runCmd)
 }
 
 func runCmdFn(cmd *cobra.Command, args []string) {
@@ -59,7 +60,7 @@ func runCmdFn(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("Cannot create a serving client: %+v", err))
 	}
 
-	err = functionImage.RunImage(servingClient.ServingV1alpha1(), serviceName, config.NAMESPACE)
+	err = functionImage.RunImage(servingClient.ServingV1alpha1(), serviceName, config.Namespace)
 
 	if err != nil {
 		panic(fmt.Sprintf("Cannot deploy the service: %+v", err))

--- a/example-fn.js
+++ b/example-fn.js
@@ -1,4 +1,0 @@
-module.exports = context => {
-  const ret = 'This is the test function for Node.js FaaS';
-  return ret;
-};

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,21 +1,23 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/image/types"
+	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
 	"path"
+	"path/filepath"
 )
 
 const (
-	TARGET_DIR_ENV      = "target_dir"
-	RUNTIME_DIR_ENV     = "runtime_dir"
-	EDITING_DIR_ENV		= "editing_dir"
+	KFN_DIR_ENV         = "kfn_dir"
 	VERBOSE             = "verbose"
 	REGISTRY            = "registry"
 	REGISTRY_USERNAME   = "registry_username"
@@ -23,30 +25,35 @@ const (
 	REGISTRY_TLS_VERIFY = "registry_tls_verify"
 	KUBECONFIG          = "kubeconfig"
 	DEBUG               = "kfn_debug"
-	CONFIG				= "config"
-	NAMESPACE			= "namespace"
+	CONFIG              = "config"
+	NAMESPACE           = "namespace"
 )
 
 const (
+	kfnDirBase     string = ".kfn"
 	targetDirBase  string = "target"
 	runtimeDirBase string = "runtime"
 	editingDirBase string = "editing"
 )
 
 var (
-	TargetDir              string
-	RuntimeDir             string
-	EditingDir			   string
+	KfnDir                 string
 	Verbose                bool
+	RuntimeDir             string
 	Debug                  bool
 	ImageRegistry          string
 	ImageRegistryUsername  string
 	ImageRegistryPassword  string
 	ImageRegistryTLSVerify bool
 	Kubeconfig             string
+	Namespace              string
 	BuildahIsolation       buildah.Isolation
 	BuildSystemContext     *types.SystemContext
 )
+
+func init() {
+
+}
 
 func InitLogging() {
 	Verbose = getEnvBoolOrDefault(VERBOSE, false)
@@ -60,13 +67,46 @@ func InitLogging() {
 	}
 }
 
-func InitDirVariables() {
-	wd, _ := os.Getwd()
+func GetKfnDir() string {
+	KfnDir = getEnvStringOrDefault(KFN_DIR_ENV, kfnDirBase)
+	home, _ := homedir.Dir()
+	if !filepath.IsAbs(KfnDir) {
+		KfnDir = path.Join(home, KfnDir)
+	}
 
-	// Configure variables
-	TargetDir = path.Join(wd, getEnvStringOrDefault(TARGET_DIR_ENV, targetDirBase))
-	RuntimeDir = path.Join(wd, getEnvStringOrDefault(RUNTIME_DIR_ENV, runtimeDirBase))
-	EditingDir = path.Join(wd, getEnvStringOrDefault(EDITING_DIR_ENV, editingDirBase))
+	return KfnDir
+}
+
+func InitKfnDir() {
+	KfnDir = getEnvStringOrDefault(KFN_DIR_ENV, kfnDirBase)
+
+	// If filepath is absolute, leave as is
+	if !filepath.IsAbs(KfnDir) {
+		home, err := homedir.Dir()
+
+		// Try to resolve starting from home dir
+		if err == nil {
+			KfnDir = path.Join(home, KfnDir)
+		} else {
+			// Cannot resolve home dir (it can happen in container environments), start from pwd
+			KfnDir, err = filepath.Abs(KfnDir)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	RuntimeDir = path.Join(KfnDir, runtimeDirBase)
+
+	log.Debugf("Kfn dir: %s", KfnDir)
+}
+
+func GetTargetDir(functionLocation string) string {
+	return path.Join(KfnDir, getFunctionHash(functionLocation), targetDirBase)
+}
+
+func GetEditingDir(functionLocation string) string {
+	return path.Join(KfnDir, getFunctionHash(functionLocation), editingDirBase)
 }
 
 func InitBuildVariables(cmd *cobra.Command) error {
@@ -90,6 +130,7 @@ func InitBuildVariables(cmd *cobra.Command) error {
 
 func InitRunVariables() {
 	Kubeconfig = getEnvStringOrDefault(KUBECONFIG, "")
+	Namespace = getEnvStringOrDefault(NAMESPACE, "default")
 }
 
 func getBuildahIsolation() buildah.Isolation {
@@ -157,4 +198,8 @@ func setSystemContextCredentials(sysContext *types.SystemContext, username, pass
 			Password: password,
 		}
 	}
+}
+
+func getFunctionHash(functionLocation string) string {
+	return hex.EncodeToString(sha256.New().Sum([]byte(functionLocation)))
 }

--- a/pkg/languages/language.go
+++ b/pkg/languages/language.go
@@ -15,24 +15,24 @@ func (l Language) CheckCompileDependencies() error {
 	return ResolveLanguageManager(l).CheckCompileDependencies()
 }
 
-func (l Language) Compile(inputFile string) (string, []string, error) {
-	return ResolveLanguageManager(l).Compile(inputFile)
+func (l Language) Compile(mainFile string, targetDirectory string) (string, []string, error) {
+	return ResolveLanguageManager(l).Compile(mainFile, targetDirectory)
 }
 
 func (l Language) DownloadRuntimeIfRequired() error {
 	return ResolveLanguageManager(l).DownloadRuntimeIfRequired()
 }
 
-func (l Language) ConfigureEditingDirectory(mainFile string) (string, string, error) {
-	return ResolveLanguageManager(l).ConfigureEditingDirectory(mainFile)
+func (l Language) ConfigureEditingDirectory(mainFile string, editingDirectory string) (string, string, error) {
+	return ResolveLanguageManager(l).ConfigureEditingDirectory(mainFile, editingDirectory)
 }
 
-func (l Language) ConfigureTargetDirectory(mainFile string) error {
-	return ResolveLanguageManager(l).ConfigureTargetDirectory(mainFile)
+func (l Language) ConfigureTargetDirectory(mainFile string, targetDirectory string) error {
+	return ResolveLanguageManager(l).ConfigureTargetDirectory(mainFile, targetDirectory)
 }
 
-func (l Language) BuildImage(systemContext *types.SystemContext, imageName string, imageTag string, mainExecutable string, additionalFiles []string) (image.FunctionImage, error) {
-	return ResolveLanguageManager(l).BuildImage(systemContext, imageName, imageTag, mainExecutable, additionalFiles)
+func (l Language) BuildImage(systemContext *types.SystemContext, imageName string, imageTag string, mainExecutable string, additionalFiles []string, targetDirectory string) (image.FunctionImage, error) {
+	return ResolveLanguageManager(l).BuildImage(systemContext, imageName, imageTag, mainExecutable, additionalFiles, targetDirectory)
 }
 
 const (

--- a/pkg/languages/language_manager.go
+++ b/pkg/languages/language_manager.go
@@ -16,16 +16,16 @@ type LanguageManager interface {
 	DownloadRuntimeIfRequired() error
 
 	// Configure a temp directory with symlinks required to edit the file
-	ConfigureEditingDirectory(mainFile string) (directory string, descriptorFilename string, err error)
+	ConfigureEditingDirectory(mainFile string, editingDirectory string) (directory string, descriptorFilename string, err error)
 
 	// Configure target directory
-	ConfigureTargetDirectory(mainFile string) error
+	ConfigureTargetDirectory(mainFile string, targetDirectory string) error
 
 	// Compile with Main input file, returns executable + additional files to copy
-	Compile(mainFile string) (mainExecutable string, additionalFiles []string, err error)
+	Compile(mainFile string, targetDirectory string) (mainExecutable string, additionalFiles []string, err error)
 
 	// Build the container image
-	BuildImage(systemContext *types.SystemContext, imageName string, imageTag string, mainExecutable string, additionalFiles []string) (image.FunctionImage, error)
+	BuildImage(systemContext *types.SystemContext, imageName string, imageTag string, mainExecutable string, additionalFiles []string, targetDirectory string) (image.FunctionImage, error)
 }
 
 var (

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -211,11 +211,9 @@ func CopyOrLink(link bool) func(string, string) error {
 func RmR(path ...string) error {
 	for _, p := range path {
 		if !FsExist(p) {
-			return nil
+			continue
 		}
-
-		cmd := exec.Command("rm", "-r", p)
-		err := cmd.Run()
+		err := os.RemoveAll(p)
 		if !os.IsNotExist(err) {
 			return err
 		}

--- a/pkg/util/image_builder.go
+++ b/pkg/util/image_builder.go
@@ -8,10 +8,10 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/opencontainers/go-digest"
+	log "github.com/sirupsen/logrus"
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/slinkydeveloper/kfn/pkg/image"
 	"strings"
-	log "github.com/sirupsen/logrus"
 )
 
 var digester = digest.Canonical.Digester()
@@ -72,6 +72,8 @@ func RunCommands(builder *buildah.Builder, commands ...BuildCommand) error {
 		Isolation: config.BuildahIsolation,
 	}
 	for _, cmd := range commands {
+		log.Infof("Running command %s in directory %s", cmd.Command, cmd.Wd)
+
 		command := strings.Split(cmd.Command, " ")
 
 		if cmd.Wd != "" {


### PR DESCRIPTION
Closes #14
`target`, `runtime` and `editing` no longer live in the same directory where the function lives, but under a unique `.kfn` directory tree in the user home directory