### PR TITLE
feat: support a user package.json file

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,14 +17,15 @@ package cmd
 
 import (
 	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
 	"github.com/containers/buildah/pkg/unshare"
 	"github.com/slinkydeveloper/kfn/pkg"
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/slinkydeveloper/kfn/pkg/image"
 	"github.com/slinkydeveloper/kfn/pkg/languages"
-	"path"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 

--- a/pkg/kfn.go
+++ b/pkg/kfn.go
@@ -2,17 +2,18 @@ package pkg
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/containers/image/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/slinkydeveloper/kfn/pkg/image"
 	"github.com/slinkydeveloper/kfn/pkg/languages"
 	"github.com/slinkydeveloper/kfn/pkg/util"
-	"io/ioutil"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 func init() {
@@ -103,7 +104,7 @@ func Build(location string, language languages.Language, imageName string, image
 		return image.FunctionImage{}, err
 	}
 
-	log.Info("Starting build image")
+	log.Infof("Building image %s\n", imageName)
 
 	return languageManager.BuildImage(systemContext, imageName, imageTag, compiledOutput, additionalFiles, targetDir)
 }

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -3,7 +3,6 @@ package util
 import (
 	"archive/zip"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"os/exec"
@@ -11,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func FileExist(p ...string) bool {


### PR DESCRIPTION
This commit modifies the JS language implementation so that
it will look for a user provided package.json in the same directory
as the function file. If one exists, it uses this instead of the
generated one.
    
NB: This does mean that if a user has provided function dependency
information in the function file in the form:
    
```js
// kfn:dependency primal 0.2.3
 ```
These dependencies will be superceded by what is found in package.json

This commit includes the changes in https://github.com/openshift-cloud-functions/kfn/pull/25