### PR TITLE
src: ConfigureEditingDirectory returns dir and err

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -17,13 +17,14 @@ package cmd
 
 import (
 	"fmt"
+	"path"
+	"path/filepath"
+
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/slinkydeveloper/kfn/pkg/editors"
 	"github.com/slinkydeveloper/kfn/pkg/languages"
 	"github.com/slinkydeveloper/kfn/pkg/util"
 	"github.com/spf13/cobra"
-	"path"
-	"path/filepath"
 )
 
 // editCmd represents the edit command
@@ -67,12 +68,12 @@ func editCmdFn(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	directory, descriptorFilename, err := language.ConfigureEditingDirectory(functionPath, functionConfiguration, editingDir)
+	directory, err := language.ConfigureEditingDirectory(functionPath, functionConfiguration, editingDir)
 	if err != nil {
 		return err
 	}
 
-	err = ed.OpenEditor(directory, descriptorFilename)
+	err = ed.OpenEditor(directory)
 	if err != nil {
 		return err
 	}

--- a/pkg/editors/editor.go
+++ b/pkg/editors/editor.go
@@ -2,9 +2,10 @@ package editors
 
 import (
 	"fmt"
-	"github.com/slinkydeveloper/kfn/pkg/util"
 	"os/exec"
+
 	log "github.com/sirupsen/logrus"
+	"github.com/slinkydeveloper/kfn/pkg/util"
 )
 
 type Editor uint8
@@ -27,7 +28,7 @@ func GetEditor(editor string) Editor {
 	return Unknown
 }
 
-func (e Editor) OpenEditor(directory string, descriptorFilename string) error {
+func (e Editor) OpenEditor(directory string) error {
 	switch e {
 	case Idea:
 		return startEditorProcess(directory, "idea", directory)

--- a/pkg/languages/js/js.go
+++ b/pkg/languages/js/js.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+
 	"github.com/containers/image/types"
 	"github.com/sirupsen/logrus"
 	"github.com/slinkydeveloper/kfn/pkg/config"
 	"github.com/slinkydeveloper/kfn/pkg/image"
 	"github.com/slinkydeveloper/kfn/pkg/languages"
 	"github.com/slinkydeveloper/kfn/pkg/util"
-	"io/ioutil"
-	"path"
-	"strings"
 )
 
 const (
@@ -130,24 +131,24 @@ func (j jsLanguageManager) DownloadRuntimeIfRequired() error {
 	return nil
 }
 
-func (r jsLanguageManager) ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (string, string, error) {
+func (r jsLanguageManager) ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (string, error) {
 	functionFile := path.Join(editingDirectory, "index.js")
 	err := util.Link(mainFile, functionFile)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	packageJson, err := generatePackageJson(functionConfiguration)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	err = util.WriteFiles(editingDirectory, util.WriteDest{Filename: "package.json", Data: packageJson})
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return editingDirectory, path.Join(editingDirectory, "package.json"), nil
+	return editingDirectory, nil
 }
 
 func (j jsLanguageManager) ConfigureTargetDirectory(mainFile string, functionConfiguration map[string][]string, targetDirectory string) error {

--- a/pkg/languages/language.go
+++ b/pkg/languages/language.go
@@ -23,7 +23,7 @@ func (l Language) DownloadRuntimeIfRequired() error {
 	return ResolveLanguageManager(l).DownloadRuntimeIfRequired()
 }
 
-func (l Language) ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (string, string, error) {
+func (l Language) ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (string, error) {
 	return ResolveLanguageManager(l).ConfigureEditingDirectory(mainFile, functionConfiguration, editingDirectory)
 }
 

--- a/pkg/languages/language_manager.go
+++ b/pkg/languages/language_manager.go
@@ -16,7 +16,7 @@ type LanguageManager interface {
 	DownloadRuntimeIfRequired() error
 
 	// Configure a temp directory with symlinks required to edit the file
-	ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (directory string, descriptorFilename string, err error)
+	ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (directory string, err error)
 
 	// Configure target directory
 	ConfigureTargetDirectory(mainFile string, functionConfiguration map[string][]string, targetDirectory string) error

--- a/pkg/languages/rust/rust.go
+++ b/pkg/languages/rust/rust.go
@@ -3,6 +3,13 @@ package rust
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+
 	"github.com/containers/image/types"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
@@ -12,12 +19,6 @@ import (
 	"github.com/slinkydeveloper/kfn/pkg/image"
 	"github.com/slinkydeveloper/kfn/pkg/languages"
 	"github.com/slinkydeveloper/kfn/pkg/util"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -92,25 +93,25 @@ func (r rustLanguageManager) CheckCompileDependencies() error {
 	return util.CommandsExists("rustc", "cargo", "musl-gcc")
 }
 
-func (r rustLanguageManager) ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (string, string, error) {
+func (r rustLanguageManager) ConfigureEditingDirectory(mainFile string, functionConfiguration map[string][]string, editingDirectory string) (string, error) {
 	functionFile := path.Join(editingDirectory, "lib.rs")
 
 	cargoToml, err := generateCargoToml(functionConfiguration)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	err = util.WriteFiles(editingDirectory, util.WriteDest{Filename: "Cargo.toml", Data: cargoToml})
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	err = util.Link(mainFile, functionFile)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return editingDirectory, path.Join(editingDirectory, "Cargo.toml"), nil
+	return editingDirectory, nil
 }
 func (r rustLanguageManager) ConfigureTargetDirectory(mainFile string, functionConfiguration map[string][]string, targetDirectory string) error {
 	if err := util.MkdirpIfNotExists(path.Join(targetDirectory, "function")); err != nil {


### PR DESCRIPTION
This commit removes the "descriptor" file from the return value of
language.ConfigureEditingDirectory as this return value was never used.
Also included are 'go lint' changes on the modified files.